### PR TITLE
Prompt for monarch path when running the monarch mix task

### DIFF
--- a/lib/mix/tasks/monarch.ex
+++ b/lib/mix/tasks/monarch.ex
@@ -16,23 +16,23 @@ defmodule Mix.Tasks.Monarch do
   def run(args) do
     case OptionParser.parse!(args, switches: @switches) do
       {opts, [base_name]} ->
-        path = opts[:monarch_path] || :code.priv_dir(:my_app)
-
-        app_dir = File.cwd!()
-        file_name = "#{base_name}.ex"
-        file = Path.join([app_dir, path, file_name])
-        unless File.dir?(path), do: create_directory(path)
+        path = opts[:monarch_path]
 
         module_path =
-          if opts[:monarch_path] do
-            split_string_list = String.split(opts[:monarch_path], "lib/")
+          if path do
+            split_string_list = String.split(path, "lib/")
 
             split_string_list
             |> List.last()
             |> camelize()
           else
-            camelize("monarch")
+            Mix.raise("expected to receive a monarch_path argument")
           end
+
+        app_dir = File.cwd!() |> IO.inspect
+        file_name = "#{base_name}.ex"
+        file = Path.join([app_dir, path, file_name])
+        unless File.dir?(path), do: create_directory(path)
 
         assigns = [mod: Module.concat([module_path, camelize(base_name)])]
         create_file(file, monarch_template(assigns))

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Monarch.MixProject do
   def project do
     [
       app: :monarch,
-      version: "0.1.1",
+      version: "0.1.2",
       elixir: "~> 1.15.7",
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),

--- a/test/monarch_test.exs
+++ b/test/monarch_test.exs
@@ -88,7 +88,7 @@ defmodule MonarchTest do
       Monarch.run(Monarch.Oban, "test")
 
       assert 4 = length(all_enqueued(worker: Monarch.Worker))
-      refute_enqueued worker: MonarchTestAlreadyCompletedJob
+      refute_enqueued(worker: MonarchTestAlreadyCompletedJob)
     end
 
     test "will not queue a job that has scheduled_at nil" do
@@ -103,7 +103,7 @@ defmodule MonarchTest do
       Monarch.run(Monarch.Oban, "test")
 
       assert 5 = length(all_enqueued(worker: Monarch.Worker))
-      refute_enqueued worker: MonarchTestManualJob
+      refute_enqueued(worker: MonarchTestManualJob)
     end
   end
 

--- a/test/monarch_test_jobs.ex
+++ b/test/monarch_test_jobs.ex
@@ -166,7 +166,6 @@ defmodule MonarchTestScheduledFutureJob do
   end
 end
 
-
 defmodule MonarchTestScheduledPastJob do
   @moduledoc """
   A module that implements a monarch job that should be scheduled at the beginning of the day.


### PR DESCRIPTION
## What changed

- `Mix raise` if mix task does not receive `monarch_path`

## Testing steps

Run `mix monarch test-file-name` and verify you receive an error in the terminal prompting you for `monarch_path`