### PR TITLE
Bump version

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Monarch.MixProject do
   def project do
     [
       app: :monarch,
-      version: "0.1.3",
+      version: "0.1.4",
       elixir: "~> 1.17.2",
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
This is already deployed on hex.pm but not sure how the version bump didn't get committed.

This PR just makes it consistent on `main` with the latest release.