### PR TITLE
Use String.to_atom/1 instead of String.to_existing_atom/1

### DIFF
--- a/lib/monarch/worker.ex
+++ b/lib/monarch/worker.ex
@@ -11,8 +11,8 @@ defmodule Monarch.Worker do
 
   @impl Oban.Worker
   def perform(job) do
-    worker = String.to_existing_atom(job.args["job"])
-    repo = String.to_existing_atom(job.args["repo"])
+    worker = String.to_atom(job.args["job"])
+    repo = String.to_atom(job.args["repo"])
 
     {:ok, {action, resp}} =
       cond do

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Monarch.MixProject do
   def project do
     [
       app: :monarch,
-      version: "0.1.4",
+      version: "0.1.5",
       elixir: "~> 1.17.2",
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
We are seeing some errors come through when using `String.to_existing_atom/1`. To prevent these we can just `String.to_atom/1` instead. 

We shouldn't have to worry about issues with overusing atom creation here because the `perform` should only get executed on new monarch jobs that haven't been run, which makes sense why the atom wouldn't have existed already.

Realistically, the only atom that could exist is the `repo` atom, and we can't guarantee that it already exists yet. So it is safer for us to use `to_atom` for both the `worker` and `repo` instances.