### PR TITLE
🐛 Skipped Monarch jobs should get logged as completed

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.17.2
+elixir 1.18.1
 erlang 27.0.1

--- a/config/config.exs
+++ b/config/config.exs
@@ -17,3 +17,12 @@ config :monarch, Oban,
   name: Monarch.Oban,
   repo: Monarch.Repo,
   testing: :manual
+
+case Mix.env() do
+  :test ->
+    import_config "test.exs"
+
+  _ ->
+    # No action for other environments
+    nil
+end

--- a/config/config.exs
+++ b/config/config.exs
@@ -3,26 +3,4 @@ import Config
 config :monarch,
   environment: config_env()
 
-config :monarch, Monarch.Repo,
-  database: "monarch_repo",
-  username: "postgres",
-  password: "postgres",
-  hostname: "localhost",
-  pool: Ecto.Adapters.SQL.Sandbox
-
-config :monarch,
-  ecto_repos: [Monarch.Repo]
-
-config :monarch, Oban,
-  name: Monarch.Oban,
-  repo: Monarch.Repo,
-  testing: :manual
-
-case Mix.env() do
-  :test ->
-    import_config "test.exs"
-
-  _ ->
-    # No action for other environments
-    nil
-end
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -14,6 +14,3 @@ config :monarch, Oban,
   name: Monarch.Oban,
   repo: Monarch.Repo,
   testing: :manual
-
-config :logger,
-  level: :info

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,0 +1,1 @@
+import Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,4 @@
+import Config
+
+config :logger,
+  level: :info

--- a/lib/mix/tasks/monarch.ex
+++ b/lib/mix/tasks/monarch.ex
@@ -1,7 +1,9 @@
 defmodule Mix.Tasks.Monarch do
   @shortdoc "Creates a skeleton file that implements the monarch behaviour."
 
-  @moduledoc "The monarch mix task: `mix help monarch`"
+  @moduledoc """
+  The monarch mix task: `mix help monarch`
+  """
 
   use Mix.Task
 

--- a/lib/monarch/worker.ex
+++ b/lib/monarch/worker.ex
@@ -17,6 +17,7 @@ defmodule Monarch.Worker do
     {:ok, {action, resp}} =
       cond do
         worker.skip() ->
+          :ok = log_completed!(repo, worker)
           {:ok, {:halt, []}}
 
         function_exported?(worker, :snooze?, 0) && worker.snooze?() ->
@@ -49,8 +50,6 @@ defmodule Monarch.Worker do
         :ok
 
       # Recursively perform the Oban job if there are still records to be updated.
-      # TODO: should we re-enqueue this working so it runs in a different pod?
-      #       if so we'll have to do this differently.
       :cont ->
         perform(%{job | args: Map.put(job.args, "chunk", resp)})
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Monarch.MixProject do
     [
       app: :monarch,
       version: "0.1.6",
-      elixir: "~> 1.17.2",
+      elixir: "~> 1.18.1",
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),
       elixirc_paths: ["lib/", "test/"],

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Monarch.MixProject do
   def project do
     [
       app: :monarch,
-      version: "0.1.5",
+      version: "0.1.6",
       elixir: "~> 1.17.2",
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),

--- a/test/monarch_test_jobs.ex
+++ b/test/monarch_test_jobs.ex
@@ -19,6 +19,26 @@ if Mix.env() == :test do
     def update(_), do: :ok
   end
 
+  defmodule MonarchTestSkipJob do
+    @moduledoc """
+    A module that always skips
+    """
+
+    @behaviour Monarch
+
+    @impl Monarch
+    def skip, do: true
+
+    @impl Monarch
+    def scheduled_at, do: DateTime.utc_now()
+
+    @impl Monarch
+    def query, do: [1, 2, 3]
+
+    @impl Monarch
+    def update(_), do: :ok
+  end
+
   defmodule MonarchTestSnoozeJob do
     @moduledoc """
     A module that always snoozes


### PR DESCRIPTION
Noticed that a job that was marked with the `skip` attribute was not getting logged as completed.
This would cause the inserted oban job itself to complete but would always get reinserted on app start because there was no `monarch_job` record to let Monarch know the job should not get reinserted because it is already complete.

If you read our documentation this is the expected behaviour:

> `skip/0` - Specifies whether to skip executing the job. Skipping will mark the Monarch job as complete but will not actually run what is specified in the module. This is useful for example if you want to run a particular job only on certain environments. You could specify: `Application.get_env(:monarch, Monarch)[:deploy_environment] != :production` in a Monarch behaviour module and it would skip executing Monarch jobs that are not production but still mark them as complete in the current environment so they are not attempted to run again.

