### PR TITLE
Explicitly set primary key for monarch_jobs table

### DIFF
--- a/lib/monarch/migrations.ex
+++ b/lib/monarch/migrations.ex
@@ -7,7 +7,8 @@ defmodule Monarch.Migrations do
 
   @spec up(Keyword.t()) :: :ok
   def up(version: 1) do
-    create table(:monarch_jobs) do
+    create table(:monarch_jobs, primary_key: false) do
+      add(:id, :bigserial, primary_key: true)
       add(:name, :string, null: false)
       add(:inserted_at, :utc_datetime, null: false)
     end


### PR DESCRIPTION
The current migration creates the primary key automatically based on whatever settings the application has. In fact Monarch expects a bigserial autoincremental primary key so any other type won't work and result in a failed job when trying to record the result in the `monarch_jobs` table.

This commit fixes it by setting the primary key type and column explicitly [just like Oban does](https://github.com/oban-bg/oban/blob/584e86a8515b7cb8d6eff2f148fb880529fc68f8/lib/oban/migrations/postgres/v01.ex#L30).